### PR TITLE
Data: Adjust xml rule index to point to attribute value instead of tag

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/JqaXmlRuleIndexingStrategy.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/JqaXmlRuleIndexingStrategy.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.xml.XmlTag
+import com.intellij.psi.xml.XmlAttributeValue
 import com.intellij.util.AstLoadingFilter
 import com.intellij.util.indexing.FileBasedIndex
 import org.jqassistant.tooling.intellij.plugin.data.rules.*
@@ -40,7 +40,11 @@ class JqaXmlRuleIndexingStrategy(
                     val psiFile = psiManager.findFile(file)
                     val psiElement = AstLoadingFilter.forceAllowTreeLoading<PsiElement?, Throwable>(psiFile) {
                         val token = psiFile?.findElementAt(value)
-                        return@forceAllowTreeLoading PsiTreeUtil.getParentOfType(token, XmlTag::class.java, false)
+                        return@forceAllowTreeLoading PsiTreeUtil.getParentOfType(
+                            token,
+                            XmlAttributeValue::class.java,
+                            false
+                        )
                     }
 
                     if (psiElement == null) return@processValues true

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/NameIndex.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/NameIndex.kt
@@ -16,7 +16,7 @@ import org.jqassistant.tooling.intellij.plugin.common.toMutableMap
 class NameIndex : FileBasedIndexExtension<String, Int>() {
     object Util {
         val NAME = ID.create<String, Int>("jqassistant.rules.xml.NameIndex")
-        const val VERSION = 1
+        const val VERSION = 2
     }
 
     override fun getName(): ID<String, Int> = Util.NAME
@@ -32,7 +32,7 @@ class NameIndex : FileBasedIndexExtension<String, Int>() {
             return listOf(root.concepts, root.constraints, root.groups).flatMap { ruleSet ->
                 ruleSet.mapNotNull {
                     val name = it.id.value ?: return@mapNotNull null
-                    val offset = it.xmlTag?.textOffset ?: return@mapNotNull null
+                    val offset = it.id.xmlAttributeValue?.textOffset ?: return@mapNotNull null
                     name to offset
                 }
             }.toMutableMap()


### PR DESCRIPTION
Required to make renaming work. IntelliJ doesn't seem to properly rebuild the index so it might be necessary to clear indexes: `File > Invalidate Caches...`