### PR TITLE
Data+Editor: Add jQA plugins to external libs view

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,21 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     implementation(libs.jqa.core.report) {
-        // jqa.core has runtime dependency on neo4j integration tests, the intellij plugin wont't need those integration tests
+        // jqa.core has runtime dependency on neo4j integration tests, the intellij plugin can't handle those integration tests
         exclude(group = "org.neo4j.community")
     }
-    implementation(libs.jqa.core.schemata)
+    implementation(libs.jqa.core.schemata) {
+        exclude(group = "org.neo4j.community")
+    }
+    implementation(libs.jqa.core.configuration) {
+        exclude(group = "org.neo4j.community")
+    }
+    implementation(libs.jqa.core.runtime) {
+        exclude(group = "org.neo4j.community")
+    }
+    implementation(libs.jqa.cli.application) {
+        exclude(group = "org.neo4j.community")
+    }
 
     testImplementation(libs.junit)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,11 @@ junit = "4.13.2"
 
 jqa-core-report = "2.5.0"
 jqa-core-schemata = "2.5.0"
+jqa-core-configuration = "2.0.0-RC1"
+jqa-core-runtime = "2.5.0"
+jqa-cli-application = "2.5.0"
+
+maven-bom = "3.9.9"
 
 
 # plugins
@@ -17,6 +22,13 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 jqa-core-report = { group = "com.buschmais.jqassistant.core", name = "report", version.ref = "jqa-core-report" }
 jqa-core-schemata = { group = "com.buschmais.jqassistant.core", name = "schemata", version.ref = "jqa-core-schemata" }
+jqa-core-configuration = { group = "com.buschmais.jqassistant.core", name = "configuration", version.ref = "jqa-core-configuration" }
+jqa-core-runtime = { group = "com.buschmais.jqassistant.core", name = "runtime", version.ref = "jqa-core-runtime" }
+jqa-cli-application = { group = "com.buschmais.jqassistant.cli", name = "application", version.ref = "jqa-cli-application" }
+
+maven-bom = { module = "org.apache.maven:maven-bom", version.ref = "maven-bom" }
+maven-core = { group = "org.apache.maven", name = "maven-core", version.ref = "maven-bom" }
+maven-compat = { group = "org.apache.maven", name = "maven-compat", version.ref = "maven-bom" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginRootsProvider.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginRootsProvider.kt
@@ -1,0 +1,62 @@
+package org.jqassistant.tooling.intellij.plugin.data.plugin
+
+import com.buschmais.jqassistant.core.shared.configuration.Plugin
+import com.intellij.icons.AllIcons
+import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
+import com.intellij.openapi.roots.SyntheticLibrary
+import com.intellij.openapi.vfs.JarFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import java.io.File
+import javax.swing.Icon
+
+/**
+ * A synthetic library representing an jQA-Plugin.
+ *
+ * Will be displayed in the external libraries view of the project pane.
+ */
+class JqaPluginLibrary(
+    private val plugin: Plugin,
+    private val roots: List<File>,
+) : SyntheticLibrary(),
+    ItemPresentation {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        val otherLib = other as? JqaPluginLibrary ?: return false
+
+        return otherLib.plugin == plugin
+    }
+
+    override fun hashCode(): Int = plugin.hashCode()
+
+    override fun getSourceRoots(): MutableCollection<VirtualFile> {
+        val virtualFiles = roots.mapNotNull { VfsUtil.findFileByIoFile(it, true) }
+        val resolvedJars =
+            virtualFiles.mapTo(mutableListOf()) {
+                JarFileSystem.getInstance().getJarRootForLocalFile(it) ?: it
+            }
+
+        return resolvedJars
+    }
+
+    // TODO: Can [artifactId()] contain multiple artifacts?
+    override fun getPresentableText(): String = "jQA: ${plugin.groupId()}:${plugin.artifactId()[0]}:${plugin.version()}"
+
+    override fun getIcon(unused: Boolean): Icon = AllIcons.Nodes.PpLibFolder
+}
+
+/**
+ * Provides jQA-Plugins in form of [JqaPluginLibrary] to IntelliJ.
+ *
+ * See [JqaPluginService] for how jQA-Plugins are managed and how this gets updated.
+ */
+class JqaPluginRootsProvider : AdditionalLibraryRootsProvider() {
+    override fun getAdditionalProjectLibraries(project: Project): Collection<SyntheticLibrary> =
+        project.service<JqaPluginService>().plugins.map { (plugin, roots) ->
+            JqaPluginLibrary(plugin, roots)
+        }
+}

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginService.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginService.kt
@@ -1,0 +1,102 @@
+package org.jqassistant.tooling.intellij.plugin.data.plugin
+
+import com.buschmais.jqassistant.commandline.configuration.CliConfiguration
+import com.buschmais.jqassistant.commandline.plugin.ArtifactProviderFactory
+import com.buschmais.jqassistant.core.runtime.api.configuration.ConfigurationMappingLoader
+import com.buschmais.jqassistant.core.shared.configuration.Plugin
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.AdditionalLibraryRootsListener
+import io.smallrye.config.SysPropConfigSource
+import java.io.File
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * Handles installation and localization of jQA-Plugins.
+ *
+ * Keeps a cache of active plugins and corresponding jar locations.
+ */
+@Service(Service.Level.PROJECT)
+class JqaPluginService(
+    private val project: Project,
+) {
+    private val userHome = File(System.getProperty("user.home"))
+
+    private data class PluginCache(
+        val plugins: Map<Plugin, List<File>>,
+    )
+
+    // TODO: Evaluate whether we can persist this.
+    @Volatile
+    private var cache: PluginCache =
+        PluginCache(
+            emptyMap(),
+        )
+
+    val plugins: Map<Plugin, List<File>> get() = cache.plugins
+
+    /**
+     * Synchronizes jQA-Plugins based on the current configuration.
+     *
+     * This methods might install plugins from the internet if they
+     * are not present so it should be called from background threads,
+     * and with a progress indicator if possible.
+     */
+    @Synchronized
+    fun synchronizePlugins() {
+        val config =
+            getJqaConfiguration() ?: return thisLogger().error("Problem constructing jQA-Config for plugin sync.")
+
+        // TODO: Figure out builtin plugins.
+        val plugins =
+            (config.defaultPlugins() + config.plugins()).filter {
+                if (it.type() == "jar") {
+                    true
+                } else {
+                    thisLogger().error("Non jar based jQA-Plugins are not supported.")
+                    false
+                }
+            }
+
+        val provider = ArtifactProviderFactory(userHome).create(config)
+
+        val mappedPlugins =
+            plugins.associateWith {
+                provider.resolve(listOf(it))
+            }
+
+        cache =
+            PluginCache(
+                mappedPlugins,
+            )
+
+        ApplicationManager.getApplication().invokeLater {
+            WriteAction.run<Throwable> {
+                // TODO: Search for a stable alternative.
+                AdditionalLibraryRootsListener.fireAdditionalLibraryChanged(
+                    project,
+                    null,
+                    emptyList(),
+                    emptyList(),
+                    JqaPluginService::class.jvmName,
+                )
+            }
+        }
+    }
+
+    // TODO: Replace with configuration service that handles maven and everything config related.
+    private fun getJqaConfiguration(): CliConfiguration? {
+        val workingDirectory = project.basePath?.let { File(it) } ?: return null
+
+        return ConfigurationMappingLoader
+            .builder(CliConfiguration::class.java, listOf(".jqassistant.yaml"))
+            .withUserHome(userHome)
+            .withWorkingDirectory(workingDirectory)
+            .withEnvVariables()
+            .withClasspath()
+            .load(SysPropConfigSource())
+    }
+}

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/xml/Dom.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/xml/Dom.kt
@@ -1,0 +1,21 @@
+package org.jqassistant.tooling.intellij.plugin.data.plugin.xml
+
+import com.intellij.util.xml.DomElement
+import com.intellij.util.xml.DomFileDescription
+import com.intellij.util.xml.TagValue
+
+interface JqassistantPlugin : DomElement {
+    val rules: List<PluginRules>
+}
+
+interface PluginRules : DomElement {
+    val resources: List<Resource>
+}
+
+interface Resource : DomElement {
+    @get:TagValue
+    val value: String
+}
+
+class JqaXmlPluginDescription :
+    DomFileDescription<JqassistantPlugin>(JqassistantPlugin::class.java, "jqassistant-plugin")

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/plugin/SynchronizePlugins.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/plugin/SynchronizePlugins.kt
@@ -1,0 +1,17 @@
+package org.jqassistant.tooling.intellij.plugin.editor.plugin
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import org.jqassistant.tooling.intellij.plugin.data.plugin.JqaPluginService
+
+class SynchronizePlugins : AnAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            project.service<JqaPluginService>().synchronizePlugins()
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,7 +36,13 @@
             implementation="org.jqassistant.tooling.intellij.plugin.data.rules.xml.JqaXmlRuleDescription"
             rootTagName="jqassistant-rules"
             stubVersion="1"/>
+        <dom.fileMetaData
+            implementation="org.jqassistant.tooling.intellij.plugin.data.plugin.xml.JqaXmlPluginDescription"
+            rootTagName="jqassistant-plugin"
+            stubVersion="1"/>
         <fileBasedIndex implementation="org.jqassistant.tooling.intellij.plugin.data.rules.xml.NameIndex"/>
+        <additionalLibraryRootsProvider
+            implementation="org.jqassistant.tooling.intellij.plugin.data.plugin.JqaPluginRootsProvider"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">
@@ -62,6 +68,8 @@
                 description="Adds a custom rules file with a custom name">
             <add-to-group group-id="NewGroup" anchor="first"/>
         </action>
+        <action id="SynchronizeJqaPlugins" text="Synchronize jQA Plugins"
+                class="org.jqassistant.tooling.intellij.plugin.editor.plugin.SynchronizePlugins"></action>
     </actions>
 
     <applicationListeners>


### PR DESCRIPTION
With this PR jqa plugins will be added to the external libraries view.

Limitations and implementation notes:
- only takes ".jqassistant.yaml" in root directory into account (e.g. no maven integration)
   - This should rely on an separate config service in the future. Integrating the maven config source seems quite tricky.
- requires manual execution of the "Synchronize jQA Plugins" action through the command palette before the plugins are added
- Rules from plugins are not indexed yet
    - will be done in a followup