### PR TITLE
Remove cache for plugin verifier step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,11 +151,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+      # Commented out because the free GitHub cache only allows 10GB which is easily filled up by the plugin verifier
+      #- name: Setup Plugin Verifier IDEs Cache
+      #  uses: actions/cache@v4
+      #  with:
+      #    path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
+      #    key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks


### PR DESCRIPTION
Commented out because the free GitHub cache only allows 10GB which is easily filled up by the plugin verifier