### PR TITLE
Data+Editor: Use `PsiPolyVariantReference` and index rules with identical name in same rule file

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingService.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingService.kt
@@ -1,6 +1,5 @@
 package org.jqassistant.tooling.intellij.plugin.data.rules
 
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.extensions.ExtensionPointListener
 import com.intellij.openapi.extensions.PluginDescriptor
@@ -17,7 +16,7 @@ import com.intellij.openapi.project.Project
  */
 @Service(Service.Level.PROJECT)
 class JqaRuleIndexingService(
-    private val project: Project
+    private val project: Project,
 ) : ExtensionPointListener<JqaRuleIndexingStrategyFactory> {
     private val indexes: MutableList<JqaRuleIndexingStrategy> = mutableListOf()
 
@@ -28,17 +27,11 @@ class JqaRuleIndexingService(
         }
     }
 
-    override fun extensionAdded(
-        extension: JqaRuleIndexingStrategyFactory,
-        pluginDescriptor: PluginDescriptor,
-    ) {
+    override fun extensionAdded(extension: JqaRuleIndexingStrategyFactory, pluginDescriptor: PluginDescriptor) {
         indexes.add(extension.create(project))
     }
 
-    override fun extensionRemoved(
-        extension: JqaRuleIndexingStrategyFactory,
-        pluginDescriptor: PluginDescriptor,
-    ) {
+    override fun extensionRemoved(extension: JqaRuleIndexingStrategyFactory, pluginDescriptor: PluginDescriptor) {
         indexes.clear()
         for (factory in JqaRuleIndexingStrategyFactory.Util.EXTENSION_POINT.extensions) {
             indexes.add(factory.create(project))
@@ -47,7 +40,7 @@ class JqaRuleIndexingService(
 
     fun getAll(type: JqaRuleType): List<JqaRuleDefinition> = indexes.flatMap { it.getAll(type) }
 
-    fun resolve(name: String): JqaRuleDefinition? = indexes.firstNotNullOfOrNull { it.resolve(name) }
+    fun resolve(identifier: String): List<JqaRuleDefinition> = indexes.flatMap { it.resolve(identifier) }
 
-    fun has(name: String): Boolean = indexes.any { it.has(name) }
+    fun has(identifier: String): Boolean = indexes.any { it.has(identifier) }
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingStrategy.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingStrategy.kt
@@ -27,7 +27,7 @@ interface JqaRuleIndexingStrategyFactory {
 interface JqaRuleIndexingStrategy {
     fun getAll(type: JqaRuleType): List<JqaRuleDefinition>
 
-    fun resolve(name: String): JqaRuleDefinition?
+    fun resolve(identifier: String): List<JqaRuleDefinition>
 
-    fun has(name: String): Boolean = resolve(name) != null
+    fun has(identifier: String): Boolean = resolve(identifier).isNotEmpty()
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/report/ReportToolWindowContent.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/report/ReportToolWindowContent.kt
@@ -134,7 +134,7 @@ class ReportToolWindowContent(
             getApplication().executeOnPooledThread {
                 val navigationElement =
                     ReadAction.compute<Navigatable?, Throwable> {
-                        val definition = ruleIndexingService.resolve(ruleId) ?: return@compute null
+                        val definition = ruleIndexingService.resolve(ruleId)[0] ?: return@compute null
 
                         val source = definition.computeSource() ?: return@compute null
 

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
@@ -2,7 +2,10 @@ package org.jqassistant.tooling.intellij.plugin.editor.rules
 
 import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
 import com.intellij.util.containers.map2Array
 import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleIndexingService
 import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
@@ -10,10 +13,11 @@ import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
 class RuleReference(
     element: PsiElement,
     private val name: String,
-) : PsiReferenceBase<PsiElement?>(element) {
+) : PsiReferenceBase<PsiElement?>(element),
+    PsiPolyVariantReference {
     override fun resolve(): PsiElement? {
-        val definition = element.project.service<JqaRuleIndexingService>().resolve(name)
-        return definition?.computeSource()
+        val results = multiResolve(false)
+        return if (results.size == 1) results[0].element else null
     }
 
     // FIXME: Remove @OptIn if IntelliJ 2023.1 support is dropped.
@@ -22,4 +26,12 @@ class RuleReference(
         JqaRuleType.entries
             .flatMap { element.project.service<JqaRuleIndexingService>().getAll(it) }
             .map2Array { it.name }
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val results = element.project.service<JqaRuleIndexingService>().resolve(name)
+        return results
+            .mapNotNull { definition ->
+                definition.computeSource()?.let { PsiElementResolveResult(it, true) }
+            }.toTypedArray()
+    }
 }


### PR DESCRIPTION
For once this adds support for rule resolution with multiple results to the edtior layer (we will need this for wildcard rules later).

It also adjusts the xml rule name index to store a `Collection<Int>` instead of `Int` so that multiple rules with the same name can be indexed per file.