### PR TITLE
Editor: Use `PsiPolyVariantReferenceBase` for rule references

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReference
-import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiPolyVariantReferenceBase
 import com.intellij.psi.ResolveResult
 import com.intellij.util.containers.map2Array
 import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleIndexingService
@@ -13,13 +13,8 @@ import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
 class RuleReference(
     element: PsiElement,
     private val name: String,
-) : PsiReferenceBase<PsiElement?>(element),
+) : PsiPolyVariantReferenceBase<PsiElement?>(element),
     PsiPolyVariantReference {
-    override fun resolve(): PsiElement? {
-        val results = multiResolve(false)
-        return if (results.size == 1) results[0].element else null
-    }
-
     // FIXME: Remove @OptIn if IntelliJ 2023.1 support is dropped.
     @OptIn(ExperimentalStdlibApi::class)
     override fun getVariants(): Array<Any> =


### PR DESCRIPTION
Before this, usage search would not find references that pointed to multiple declarations. `PsiReferenceBase` implements `isReferenceTo` in a way that doesn't work with poly references thus `PsiPolyVariantReferenceBase` must be used. The issue is also present in the simple language example from the documentation, I guess this is were we got it from.