### PR TITLE
Data+Editor: Filter completion by type

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleDefinition.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleDefinition.kt
@@ -17,7 +17,7 @@ enum class JqaRuleType {
  */
 abstract class JqaRuleDefinition(
     val name: String,
-    val type: JqaRuleType,
+    val type: JqaRuleType?,
 ) {
     abstract fun computeSource(): PsiElement?
 }
@@ -27,7 +27,7 @@ abstract class JqaRuleDefinition(
  */
 class ValueBasedJqaRuleDefinition(
     name: String,
-    type: JqaRuleType,
+    type: JqaRuleType?,
     private val element: PsiElement? = null,
 ) : JqaRuleDefinition(name, type) {
     override fun computeSource(): PsiElement? = element

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingService.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingService.kt
@@ -38,7 +38,7 @@ class JqaRuleIndexingService(
         }
     }
 
-    fun getAll(type: JqaRuleType): List<JqaRuleDefinition> = indexes.flatMap { it.getAll(type) }
+    fun getAll(type: JqaRuleType? = null): List<JqaRuleDefinition> = indexes.flatMap { it.getAll(type) }
 
     fun resolve(identifier: String): List<JqaRuleDefinition> = indexes.flatMap { it.resolve(identifier) }
 

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingStrategy.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/JqaRuleIndexingStrategy.kt
@@ -25,7 +25,7 @@ interface JqaRuleIndexingStrategyFactory {
  * One [JqaRuleIndexingStrategy] might use as many indexes as necessary under the hood.
  */
 interface JqaRuleIndexingStrategy {
-    fun getAll(type: JqaRuleType): List<JqaRuleDefinition>
+    fun getAll(type: JqaRuleType?): List<JqaRuleDefinition>
 
     fun resolve(identifier: String): List<JqaRuleDefinition>
 

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/Dom.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/Dom.kt
@@ -8,7 +8,10 @@ import com.intellij.util.xml.NameValue
 import com.intellij.util.xml.Referencing
 import com.intellij.util.xml.Stubbed
 import com.intellij.util.xml.SubTagList
-import org.jqassistant.tooling.intellij.plugin.editor.rules.XmlRuleReferenceConverter
+import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
+import org.jqassistant.tooling.intellij.plugin.editor.rules.XmlConceptReferenceConverter
+import org.jqassistant.tooling.intellij.plugin.editor.rules.XmlConstraintReferenceConverter
+import org.jqassistant.tooling.intellij.plugin.editor.rules.XmlGroupReferenceConverter
 
 @Stubbed
 interface JqassistantRules : DomElement {
@@ -22,12 +25,20 @@ interface JqassistantRules : DomElement {
     val constraints: List<Constraint>
 }
 
-interface RuleBase : DomElement {
+sealed interface RuleBase : DomElement {
     @get:Stubbed
     @get:Attribute("id")
     @get:NameValue(referencable = true)
     val id: GenericAttributeValue<String>
 }
+
+// Needs to be an extension function since IntelliJ does some magic with the interfaces.
+fun RuleBase.getType(): JqaRuleType =
+    when (this) {
+        is Group -> JqaRuleType.GROUP
+        is Concept -> JqaRuleType.CONCEPT
+        is Constraint -> JqaRuleType.CONSTRAINT
+    }
 
 @Stubbed
 interface Group :
@@ -37,19 +48,19 @@ interface Group :
     val includeConcept: List<IncludedConceptType>
 
     @get:SubTagList("includeConstraint")
-    val includeConstraint: List<IncludedReferenceType>
+    val includeConstraint: List<ConstraintType>
 
     @get:SubTagList("includeGroup")
-    val includeGroup: List<IncludedReferenceType>
+    val includeGroup: List<GroupType>
 }
 
 @Stubbed
 interface Concept :
     RuleBase,
-    DomElement,
-    ExecutableRuleType {
+    ExecutableRuleType,
+    DomElement {
     @get:SubTagList("providesConcept")
-    val providesConcept: List<ReferenceType>
+    val providesConcept: List<ConceptType>
 }
 
 @Stubbed
@@ -60,34 +71,32 @@ interface Constraint :
 
 interface ExecutableRuleType : DomElement {
     @get:SubTagList("requiresConcept")
-    val requiresConcept: List<OptionalReferenceType>
+    val requiresConcept: List<ConceptType>
 }
 
-interface ReferenceType : DomElement {
+interface GroupType : DomElement {
     @get:Attribute("refId")
-    @get:Referencing(XmlRuleReferenceConverter::class, soft = false)
+    @get:Referencing(XmlGroupReferenceConverter::class, soft = false)
     val refType: GenericAttributeValue<String>
 }
 
-interface OptionalReferenceType :
-    DomElement,
-    ReferenceType {
-    @get:Attribute("optional")
-    val optional: GenericAttributeValue<Boolean>
+interface ConstraintType : DomElement {
+    @get:Attribute("refId")
+    @get:Referencing(XmlConstraintReferenceConverter::class, soft = false)
+    val refType: GenericAttributeValue<String>
 }
 
-interface IncludedReferenceType :
-    DomElement,
-    ReferenceType {
-    @get:Attribute("severity")
-    val severity: GenericAttributeValue<String>
+interface ConceptType : DomElement {
+    @get:Attribute("refId")
+    @get:Referencing(XmlConceptReferenceConverter::class, soft = false)
+    val refType: GenericAttributeValue<String>
 }
 
 interface IncludedConceptType :
     DomElement,
-    IncludedReferenceType {
+    ConceptType {
     @get:SubTagList("providesConcept")
-    val providesConcept: List<ReferenceType>
+    val providesConcept: List<ConceptType>
 }
 
 class JqaXmlRuleDescription :

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/NameIndex.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/rules/xml/NameIndex.kt
@@ -1,6 +1,7 @@
 package org.jqassistant.tooling.intellij.plugin.data.rules.xml
 
 import com.intellij.ide.highlighter.XmlFileType
+import com.intellij.openapi.util.io.DataInputOutputUtilRt
 import com.intellij.psi.xml.XmlFile
 import com.intellij.util.indexing.DataIndexer
 import com.intellij.util.indexing.DefaultFileTypeSpecificInputFilter
@@ -9,37 +10,46 @@ import com.intellij.util.indexing.FileBasedIndexExtension
 import com.intellij.util.indexing.FileContent
 import com.intellij.util.indexing.ID
 import com.intellij.util.io.DataExternalizer
+import com.intellij.util.io.EnumDataDescriptor
+import com.intellij.util.io.EnumeratorIntegerDescriptor
 import com.intellij.util.io.EnumeratorStringDescriptor
-import com.intellij.util.io.IntCollectionDataExternalizer
 import com.intellij.util.io.KeyDescriptor
 import com.intellij.util.xml.DomManager
+import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
+import java.io.DataInput
+import java.io.DataOutput
 
 /**
- * Indexes all rules, and associates their offset in the file to their name.
+ * Indexes all rules, and associates their type and offset in the file to their name.
  */
-class NameIndex : FileBasedIndexExtension<String, Collection<Int>>() {
+class NameIndex : FileBasedIndexExtension<String, Collection<NameIndex.DeclarationStub>>() {
     object Util {
-        val NAME = ID.create<String, Collection<Int>>("jqassistant.rules.xml.NameIndex")
-        const val VERSION = 4
+        val NAME = ID.create<String, Collection<DeclarationStub>>("jqassistant.rules.xml.NameIndex")
+        const val VERSION = 5
     }
 
-    override fun getName(): ID<String, Collection<Int>> = Util.NAME
+    data class DeclarationStub(
+        val offset: Int,
+        val type: JqaRuleType,
+    )
 
-    override fun getIndexer(): DataIndexer<String, Collection<Int>, FileContent> =
-        object : DataIndexer<String, Collection<Int>, FileContent> {
-            override fun map(content: FileContent): MutableMap<String, List<Int>> {
+    override fun getName(): ID<String, Collection<DeclarationStub>> = Util.NAME
+
+    override fun getIndexer(): DataIndexer<String, Collection<DeclarationStub>, FileContent> =
+        object : DataIndexer<String, Collection<DeclarationStub>, FileContent> {
+            override fun map(content: FileContent): MutableMap<String, List<DeclarationStub>> {
                 val psiFile = content.psiFile as? XmlFile ?: return mutableMapOf()
                 val domManager = DomManager.getDomManager(psiFile.project)
                 val dom = domManager.getFileElement(psiFile, JqassistantRules::class.java) ?: return mutableMapOf()
                 val root = dom.rootElement
 
-                val res = mutableMapOf<String, List<Int>>()
+                val res = mutableMapOf<String, List<DeclarationStub>>()
                 (root.concepts + root.constraints + root.groups).forEach { rule ->
                     val name = rule.id.value ?: return@forEach
                     val offset = rule.id.xmlAttributeValue?.textOffset ?: return@forEach
 
                     val previousOffsets = res[name] ?: emptyList()
-                    res[name] = previousOffsets + offset
+                    res[name] = previousOffsets + DeclarationStub(offset, rule.getType())
                 }
                 return res
             }
@@ -47,7 +57,24 @@ class NameIndex : FileBasedIndexExtension<String, Collection<Int>>() {
 
     override fun getKeyDescriptor(): KeyDescriptor<String> = EnumeratorStringDescriptor.INSTANCE
 
-    override fun getValueExternalizer(): DataExternalizer<Collection<Int>> = IntCollectionDataExternalizer()
+    override fun getValueExternalizer(): DataExternalizer<Collection<DeclarationStub>> =
+        object : DataExternalizer<Collection<DeclarationStub>> {
+            val enumDescriptor = EnumDataDescriptor(JqaRuleType::class.java)
+
+            override fun save(output: DataOutput, data: Collection<DeclarationStub>) {
+                DataInputOutputUtilRt.writeSeq(output, data) { declaration ->
+                    EnumeratorIntegerDescriptor.INSTANCE.save(output, declaration.offset)
+                    enumDescriptor.save(output, declaration.type)
+                }
+            }
+
+            override fun read(input: DataInput): Collection<DeclarationStub> =
+                DataInputOutputUtilRt.readSeq(input) {
+                    val offset = EnumeratorIntegerDescriptor.INSTANCE.read(input)
+                    val ruleType = enumDescriptor.read(input)
+                    DeclarationStub(offset, ruleType)
+                }
+        }
 
     override fun getVersion(): Int = Util.VERSION
 

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/RuleReference.kt
@@ -10,17 +10,17 @@ import com.intellij.util.containers.map2Array
 import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleIndexingService
 import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
 
-open class RuleReference(
+class RuleReference(
     element: PsiElement,
     private val name: String,
+    private val jqaRuleType: JqaRuleType? = null,
     private val soft: Boolean = false,
 ) : PsiPolyVariantReferenceBase<PsiElement?>(element),
     PsiPolyVariantReference {
-    // FIXME: Remove @OptIn if IntelliJ 2023.1 support is dropped.
-    @OptIn(ExperimentalStdlibApi::class)
     override fun getVariants(): Array<Any> =
-        JqaRuleType.entries
-            .flatMap { element.project.service<JqaRuleIndexingService>().getAll(it) }
+        element.project
+            .service<JqaRuleIndexingService>()
+            .getAll(jqaRuleType)
             .map2Array { it.name }
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
@@ -32,17 +32,4 @@ open class RuleReference(
     }
 
     override fun isSoft() = soft
-}
-
-class SpecificRuleReference(
-    element: PsiElement,
-    name: String,
-    private val jqaRuleType: JqaRuleType,
-    soft: Boolean = false,
-) : RuleReference(element, name, soft) {
-    override fun getVariants(): Array<Any> =
-        element.project
-            .service<JqaRuleIndexingService>()
-            .getAll(jqaRuleType)
-            .map2Array { it.name }
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/UastReferenceContributor.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/UastReferenceContributor.kt
@@ -47,17 +47,17 @@ object UastReferenceProvider : UastInjectionHostReferenceProvider() {
         for (owner in annotationContext.allItems()) {
             if (owner.hasAnnotation(GroupId::class.qualifiedName!!)) {
                 return arrayOf(
-                    SpecificRuleReference(host, stringLiteralContent, JqaRuleType.GROUP, true),
+                    RuleReference(host, stringLiteralContent, JqaRuleType.GROUP, true),
                 )
             }
             if (owner.hasAnnotation(ConceptId::class.qualifiedName!!)) {
                 return arrayOf(
-                    SpecificRuleReference(host, stringLiteralContent, JqaRuleType.CONCEPT, true),
+                    RuleReference(host, stringLiteralContent, JqaRuleType.CONCEPT, true),
                 )
             }
             if (owner.hasAnnotation(ConstraintId::class.qualifiedName!!)) {
                 return arrayOf(
-                    SpecificRuleReference(host, stringLiteralContent, JqaRuleType.CONSTRAINT, true),
+                    RuleReference(host, stringLiteralContent, JqaRuleType.CONSTRAINT, true),
                 )
             }
         }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/XmlRuleReferenceConverter.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/rules/XmlRuleReferenceConverter.kt
@@ -5,14 +5,23 @@ import com.intellij.psi.PsiReference
 import com.intellij.util.xml.ConvertContext
 import com.intellij.util.xml.CustomReferenceConverter
 import com.intellij.util.xml.GenericDomValue
+import org.jqassistant.tooling.intellij.plugin.data.rules.JqaRuleType
 
-class XmlRuleReferenceConverter : CustomReferenceConverter<String> {
+open class XmlRuleReferenceConverter(
+    private val type: JqaRuleType? = null,
+) : CustomReferenceConverter<String> {
     override fun createReferences(
         value: GenericDomValue<String>?,
         element: PsiElement?,
         context: ConvertContext?,
     ): Array<PsiReference> {
         if (element == null) return emptyArray()
-        return arrayOf(RuleReference(element, value?.value ?: element.text))
+        return arrayOf(RuleReference(element, value?.value ?: element.text, type))
     }
 }
+
+class XmlGroupReferenceConverter : XmlRuleReferenceConverter(JqaRuleType.GROUP)
+
+class XmlConceptReferenceConverter : XmlRuleReferenceConverter(JqaRuleType.CONCEPT)
+
+class XmlConstraintReferenceConverter : XmlRuleReferenceConverter(JqaRuleType.CONSTRAINT)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,8 @@
      See: https://plugins.jetbrains.com/docs/intellij/uast.html#using-uast-in-plugins -->
     <depends
         optional="true"
-        config-file="jqassistant-uastReferenceContributor.xml">com.intellij.java</depends>
+        config-file="jqassistant-uastReferenceContributor.xml">com.intellij.java
+    </depends>
 
     <depends optional="true"
              config-file="jqassistant-maven.xml">
@@ -47,7 +48,7 @@
         <dom.fileMetaData
             implementation="org.jqassistant.tooling.intellij.plugin.data.rules.xml.JqaXmlRuleDescription"
             rootTagName="jqassistant-rules"
-            stubVersion="1"/>
+            stubVersion="2"/>
         <fileBasedIndex implementation="org.jqassistant.tooling.intellij.plugin.data.rules.xml.NameIndex"/>
         <additionalLibraryRootsProvider
             implementation="org.jqassistant.tooling.intellij.plugin.data.plugin.JqaPluginRootsProvider"/>


### PR DESCRIPTION
Closes #71

Also extends the filter interface so that `null` can be passed to not filter at all.
