### PR TITLE
Data: Implement JqaConfigurationService

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/common/Extensions.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/common/Extensions.kt
@@ -1,5 +1,10 @@
 package org.jqassistant.tooling.intellij.plugin.common
 
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.vfs.VirtualFile
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -52,4 +57,25 @@ inline fun <reified Loader : Any, T> Loader.withServiceLoader(block: () -> T): T
     contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
 
     return withServiceLoader(block, Loader::class.java.classLoader)
+}
+
+object MyVfsUtil {
+    /**
+     * Tries to resolve a path as relative to a project.
+     *
+     * Since projects in IntelliJ aren't strictly mappable to the file system, this method might return null for complex project setups.
+     */
+    fun findFileRelativeToProject(project: Project, relativePath: String?): VirtualFile? {
+        val base = project.guessProjectDir() ?: return null
+        if (relativePath.isNullOrBlank()) return base
+        return base.findFileByRelativePath(relativePath) ?: base
+    }
+}
+
+fun Project.notifyBalloon(message: String, type: NotificationType = NotificationType.INFORMATION) {
+    NotificationGroupManager
+        .getInstance()
+        .getNotificationGroup("jqassistant.NotificationBalloon")
+        .createNotification(message, type)
+        .notify(this)
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/common/Extensions.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/common/Extensions.kt
@@ -1,25 +1,55 @@
 package org.jqassistant.tooling.intellij.plugin.common
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
 fun <K, V> Iterable<Pair<K, V>>.toMutableMap(): MutableMap<K, V> {
     val res = mutableMapOf<K, V>()
     return associateTo(res) { it }
 }
 
 /**
- * Runs code and replaces the IntelliJ Class loader with the plugin one.
+ * Use reified overloads instead.
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T> withServiceLoader(block: () -> T, classLoader: ClassLoader?): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+    val currentThread = Thread.currentThread()
+    val originalClassLoader = currentThread.contextClassLoader
+    return try {
+        currentThread.contextClassLoader = classLoader
+        block()
+    } finally {
+        currentThread.contextClassLoader = originalClassLoader
+    }
+}
+
+/**
+ * Runs code and replaces the IntelliJ Class loader with the one of [Loader].
  *
  * This is required for code that tries to dynamically load some dependencies e.g. JAXB.
  *
  * @see [IntelliJ Platform Plugin SDK: Using ServiceLoader](https://plugins.jetbrains.com/docs/intellij/plugin-class-loaders.html#using-serviceloader)
  */
-fun <T, B : Any> B.withServiceLoader(block: () -> T): T {
-    val currentThread = Thread.currentThread()
-    val originalClassLoader = currentThread.contextClassLoader
-    val pluginClassLoader = javaClass.classLoader
-    return try {
-        currentThread.contextClassLoader = pluginClassLoader
-        block()
-    } finally {
-        currentThread.contextClassLoader = originalClassLoader
-    }
+@OptIn(ExperimentalContracts::class)
+inline fun <reified Loader : Any, T> withServiceLoader(block: () -> T): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+    return withServiceLoader(block, Loader::class.java.classLoader)
+}
+
+/**
+ * Runs code and replaces the IntelliJ Class loader with the one of [Loader].
+ *
+ * This is required for code that tries to dynamically load some dependencies e.g. JAXB.
+ *
+ * @see [IntelliJ Platform Plugin SDK: Using ServiceLoader](https://plugins.jetbrains.com/docs/intellij/plugin-class-loaders.html#using-serviceloader)
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <reified Loader : Any, T> Loader.withServiceLoader(block: () -> T): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+    return withServiceLoader(block, Loader::class.java.classLoader)
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/CliConfigFactory.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/CliConfigFactory.kt
@@ -1,0 +1,80 @@
+package org.jqassistant.tooling.intellij.plugin.data.config
+
+import com.buschmais.jqassistant.commandline.configuration.CliConfiguration
+import com.buschmais.jqassistant.commandline.task.AbstractRuleTask
+import com.buschmais.jqassistant.core.resolver.api.MavenSettingsConfigSourceBuilder
+import com.buschmais.jqassistant.core.shared.configuration.ConfigurationBuilder
+import com.buschmais.jqassistant.core.shared.configuration.ConfigurationMappingLoader
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
+import io.smallrye.config.PropertiesConfigSource
+import io.smallrye.config.SysPropConfigSource
+import org.eclipse.microprofile.config.spi.ConfigSource
+import org.jqassistant.tooling.intellij.plugin.common.withServiceLoader
+import java.io.File
+import kotlin.io.path.Path
+
+class CliConfigFactory : JqaConfigFactory {
+    override fun handlesDistribution(distribution: JqaDistribution) = distribution == JqaDistribution.CLI
+
+    override fun assembleConfig(project: Project): FullArtifactConfiguration =
+        // Use the CLI class loader to only pick up cli default plugins.
+        withServiceLoader<AbstractRuleTask, _> {
+            // Adapted from jQA
+
+            val service = project.service<JqaConfigurationService>()
+
+            val userHome = File(System.getProperty("user.home"))
+
+            val commandLineOptions = service.parseCommandLine(service.cliParameters)
+
+            val configurationBuilder = ConfigurationBuilder("TaskConfigSource", 200)
+
+            val commandLineProperties =
+                PropertiesConfigSource(commandLineOptions.properties, "Command line properties", 400)
+            val mavenSettingsConfigSource =
+                MavenSettingsConfigSourceBuilder.createMavenSettingsConfigSource(
+                    userHome,
+                    commandLineOptions.mavenSettings,
+                    commandLineOptions.profiles,
+                )
+            val configSource = configurationBuilder.build()
+
+            val workingDirectory =
+                service.cliExecutionRoot?.let { VfsUtil.virtualToIoFile(it) }
+                    ?: VfsUtil.virtualToIoFile(project.getBaseDirectories().single())
+
+            val defaultDirectory = Path(workingDirectory.absolutePath, "jqassistant", "rules")
+            val defaultPathConfig =
+                object : ConfigSource {
+                    override fun getPropertyNames() = setOf("jqassistant.analyze.rule.directory")
+
+                    override fun getValue(propertyName: String?) =
+                        if (propertyName == "jqassistant.analyze.rule.directory") defaultDirectory.toString() else null
+
+                    override fun getName() = "InlineDummy"
+
+                    override fun getOrdinal() = 401
+                }
+
+            return FullArtifactConfigurationWrapper(
+                ConfigurationMappingLoader
+                    .builder(CliConfiguration::class.java, commandLineOptions.configurationLocations)
+                    .withUserHome(userHome)
+                    .withWorkingDirectory(workingDirectory)
+                    .withClasspath()
+                    .withEnvVariables()
+                    .withProfiles(commandLineOptions.profiles)
+                    .withIgnoreProperties(setOf("jqassistant.opts", "jqassistant.home"))
+                    .load(
+                        configSource,
+                        SysPropConfigSource(),
+                        commandLineProperties,
+                        mavenSettingsConfigSource,
+                        defaultPathConfig,
+                    ),
+            )
+        }
+}

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/CliConfigFactory.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/CliConfigFactory.kt
@@ -5,30 +5,35 @@ import com.buschmais.jqassistant.commandline.task.AbstractRuleTask
 import com.buschmais.jqassistant.core.resolver.api.MavenSettingsConfigSourceBuilder
 import com.buschmais.jqassistant.core.shared.configuration.ConfigurationBuilder
 import com.buschmais.jqassistant.core.shared.configuration.ConfigurationMappingLoader
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
-import com.intellij.openapi.project.BaseProjectDirectories.Companion.getBaseDirectories
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import io.smallrye.config.PropertiesConfigSource
 import io.smallrye.config.SysPropConfigSource
-import org.eclipse.microprofile.config.spi.ConfigSource
+import org.jqassistant.tooling.intellij.plugin.common.MyVfsUtil
+import org.jqassistant.tooling.intellij.plugin.common.notifyBalloon
 import org.jqassistant.tooling.intellij.plugin.common.withServiceLoader
+import org.jqassistant.tooling.intellij.plugin.editor.MessageBundle
+import org.jqassistant.tooling.intellij.plugin.settings.PluginSettings
 import java.io.File
 import kotlin.io.path.Path
 
 class CliConfigFactory : JqaConfigFactory {
     override fun handlesDistribution(distribution: JqaDistribution) = distribution == JqaDistribution.CLI
 
-    override fun assembleConfig(project: Project): FullArtifactConfiguration =
+    override fun assembleConfig(project: Project): FullArtifactConfiguration? =
         // Use the CLI class loader to only pick up cli default plugins.
         withServiceLoader<AbstractRuleTask, _> {
             // Adapted from jQA
+
+            val settings = project.service<PluginSettings>().state
 
             val service = project.service<JqaConfigurationService>()
 
             val userHome = File(System.getProperty("user.home"))
 
-            val commandLineOptions = service.parseCommandLine(service.cliParameters)
+            val commandLineOptions = service.parseCommandLine(settings.cliParams)
 
             val configurationBuilder = ConfigurationBuilder("TaskConfigSource", 200)
 
@@ -42,22 +47,27 @@ class CliConfigFactory : JqaConfigFactory {
                 )
             val configSource = configurationBuilder.build()
 
-            val workingDirectory =
-                service.cliExecutionRoot?.let { VfsUtil.virtualToIoFile(it) }
-                    ?: VfsUtil.virtualToIoFile(project.getBaseDirectories().single())
+            val baseDir = MyVfsUtil.findFileRelativeToProject(project, settings.cliExecRootDir)
+
+            if (baseDir == null) {
+                project.notifyBalloon(
+                    MessageBundle.message("multi.root.project.not.supported"),
+                    NotificationType.ERROR,
+                )
+                return null
+            }
+
+            val workingDirectory = VfsUtil.virtualToIoFile(baseDir)
 
             val defaultDirectory = Path(workingDirectory.absolutePath, "jqassistant", "rules")
             val defaultPathConfig =
-                object : ConfigSource {
-                    override fun getPropertyNames() = setOf("jqassistant.analyze.rule.directory")
-
-                    override fun getValue(propertyName: String?) =
-                        if (propertyName == "jqassistant.analyze.rule.directory") defaultDirectory.toString() else null
-
-                    override fun getName() = "InlineDummy"
-
-                    override fun getOrdinal() = 401
-                }
+                PropertiesConfigSource(
+                    mapOf(
+                        "jqassistant.analyze.rule.directory" to defaultDirectory.toString(),
+                    ),
+                    "InlineDummy",
+                    401,
+                )
 
             return FullArtifactConfigurationWrapper(
                 ConfigurationMappingLoader

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/JqaConfigFactory.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/JqaConfigFactory.kt
@@ -1,8 +1,34 @@
 package org.jqassistant.tooling.intellij.plugin.data.config
 
+import com.buschmais.jqassistant.core.resolver.configuration.ArtifactResolverConfiguration
 import com.buschmais.jqassistant.core.runtime.api.configuration.Configuration
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
+
+/**
+ * jQA Configuration that implements all interfaces that are required for the IntelliJ plugin to use the config
+ *
+ * Union type of [Configuration] and [ArtifactResolverConfiguration].
+ * @see [FullArtifactConfigurationWrapper]
+ */
+interface FullArtifactConfiguration :
+    Configuration,
+    ArtifactResolverConfiguration
+
+/**
+ * Wrapper to represent an object implementing [Configuration] and [ArtifactResolverConfiguration] as
+ * [FullArtifactConfiguration].
+ *
+ * Since [JqaConfigFactory] is registered as extension points we can't use generics there so we use
+ * [FullArtifactConfiguration] to represent a config that fulfils the requirements for all jQA Apis we use.
+ */
+@JvmInline
+value class FullArtifactConfigurationWrapper<T>(
+    val config: T,
+) : FullArtifactConfiguration,
+    Configuration by config,
+    ArtifactResolverConfiguration by config
+    where T : Configuration, T : ArtifactResolverConfiguration
 
 /**
  * Factory for creating a jQA Config.
@@ -18,5 +44,5 @@ interface JqaConfigFactory {
 
     fun handlesDistribution(distribution: JqaDistribution): Boolean
 
-    fun createConfig(project: Project): Configuration?
+    fun assembleConfig(project: Project): FullArtifactConfiguration?
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/JqaConfigurationService.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/JqaConfigurationService.kt
@@ -1,19 +1,28 @@
 package org.jqassistant.tooling.intellij.plugin.data.config
 
-import com.buschmais.jqassistant.commandline.configuration.CliConfiguration
+import com.buschmais.jqassistant.core.resolver.api.ArtifactProviderFactory
+import com.buschmais.jqassistant.core.rule.api.executor.CollectRulesVisitor
 import com.buschmais.jqassistant.core.rule.api.model.ConceptBucket
 import com.buschmais.jqassistant.core.rule.api.model.ConstraintBucket
 import com.buschmais.jqassistant.core.rule.api.model.GroupsBucket
-import com.buschmais.jqassistant.core.rule.api.model.RuleSelection
 import com.buschmais.jqassistant.core.rule.api.model.RuleSet
+import com.buschmais.jqassistant.core.runtime.api.bootstrap.PluginRepositoryFactory
+import com.buschmais.jqassistant.core.runtime.api.bootstrap.RuleProvider
+import com.buschmais.jqassistant.core.runtime.api.plugin.PluginRepository
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.search.FilenameIndex
-import com.intellij.psi.search.ProjectScope
+import com.intellij.util.messages.Topic
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
+import org.jqassistant.tooling.intellij.plugin.common.notifyBalloon
+import org.jqassistant.tooling.intellij.plugin.common.withServiceLoader
+import org.jqassistant.tooling.intellij.plugin.editor.MessageBundle
+import org.jqassistant.tooling.intellij.plugin.settings.PluginSettings
 import java.io.File
 import java.util.Optional
 import java.util.Properties
@@ -28,7 +37,32 @@ data class CommandLineOptions(
     val mavenSettings: Optional<File>,
     val profiles: List<String>,
     val properties: Properties,
-)
+) {
+    companion object {
+        val EMPTY =
+            CommandLineOptions(
+                emptyList(),
+                Optional.empty(),
+                emptyList(),
+                Properties(),
+            )
+    }
+}
+
+/**
+ * Allows to listen to config synchronization.
+ *
+ * Can be used to derive cached values from the resolved jQA Config during the sync. At the point when
+ * listeners are notified, it is guaranteed that methods of [JqaConfigurationService]
+ * will yield results that fit the config.
+ */
+fun interface JqaSyncListener {
+    companion object {
+        val TOPIC = Topic.create("jQA Sync Listener", JqaSyncListener::class.java)
+    }
+
+    fun synchronize(config: FullArtifactConfiguration?)
+}
 
 @Service(Service.Level.PROJECT)
 class JqaConfigurationService(
@@ -36,53 +70,20 @@ class JqaConfigurationService(
 ) {
     private val jqaConfigFileProvider = JqaConfigFileProvider(project)
 
+    class State {
+        var dirty = false
+
+        var effectiveConfiguration: FullArtifactConfiguration? = null
+        var availableRuleSources: List<VirtualFile> = emptyList()
+        var availableRules: RuleSet? = null
+        var effectiveRules: CollectRulesVisitor? = null
+    }
+
+    @Volatile
+    private var state = State()
+
     @Deprecated("Don't use for new stuff as this contains the old maven effective config logic.")
     val configProvider = JqaEffectiveConfigProvider(project, jqaConfigFileProvider)
-
-    /**
-     * The distribution of this jQA project, or `null` if the project is no jQA Project.
-     */
-    var distribution: JqaDistribution?
-
-    /**
-     * Additional parameters used when the cli distribution is active.
-     */
-    var cliParameters: String = ""
-
-    /**
-     * Execution root for the cli distribution.
-     *
-     * If `null` the project root is used.
-     */
-    var cliExecutionRoot: VirtualFile? = null
-
-    /**
-     * Specific maven pom of the maven project to use for the maven distribution.
-     *
-     * If `null` any maven project with the jqa plugin will be selected.
-     */
-    var mavenProjectPom: VirtualFile? = null
-
-    /**
-     * Additional parameters used when the maven distribution is active. They are parsed in the same format as
-     * cli parameters, but only properties are supported.
-     */
-    var mavenParameters: String = ""
-
-    /**
-     * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
-     */
-    var mavenProjectDescription: String? = null
-
-    /**
-     * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
-     */
-    var mavenScriptSourceDirectory: String? = null
-
-    /**
-     * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
-     */
-    var mavenOutputEncoding: String? = null
 
     private fun gatherStandardOptions(): Options {
         // Adapted from jQA
@@ -128,17 +129,27 @@ class JqaConfigurationService(
         return options
     }
 
-    fun parseCommandLine(args: String): CommandLineOptions {
+    fun parseCommandLine(args: String?): CommandLineOptions {
+        if (args.isNullOrEmpty()) {
+            return CommandLineOptions.EMPTY
+        }
+
         // Adapted from jQA
 
         val commandLine =
-            DefaultParser().parse(
-                gatherStandardOptions(),
-                args.split(" ").toTypedArray(),
-            )
+            try {
+                DefaultParser().parse(
+                    gatherStandardOptions(),
+                    args.split(" ").toTypedArray(),
+                )
+            } catch (e: Exception) {
+                project.notifyBalloon(MessageBundle.message("invalid.cmd.options", args), NotificationType.ERROR)
+                return CommandLineOptions.EMPTY
+            }
 
-        val profiles = commandLine.getOptionValues("-profiles").filter { it.isNotEmpty() }
-        val locations = commandLine.getOptionValues("-configurationLocations").filter { it.isNotEmpty() }
+        val profiles = commandLine.getOptionValues("-profiles")?.filter { it.isNotEmpty() } ?: emptyList()
+        val locations =
+            commandLine.getOptionValues("-configurationLocations")?.filter { it.isNotEmpty() } ?: emptyList()
         val mavenSettings = Optional.ofNullable(commandLine.getOptionValue("-mavenSettings")?.let { File(it) })
         val properties = commandLine.getOptionProperties("D")
 
@@ -152,18 +163,49 @@ class JqaConfigurationService(
 
     init {
         jqaConfigFileProvider.addFileEventListener(configProvider)
+    }
 
-        // TODO: Expose as settings and use a better default strategy
-        val hasPom = FilenameIndex.getVirtualFilesByName("pom.xml", ProjectScope.getProjectScope(project)).isNotEmpty()
-        val hasJqaConfig =
-            FilenameIndex.getVirtualFilesByName(".jqassistant.yaml", ProjectScope.getProjectScope(project)).isNotEmpty()
+    fun synchronize() {
+        val settings = project.service<PluginSettings>().state
 
-        distribution =
-            when {
-                hasPom && hasJqaConfig -> JqaDistribution.MAVEN
-                hasJqaConfig -> JqaDistribution.CLI
-                else -> null
-            }
+        val factory =
+            JqaConfigFactory.Util.EXTENSION_POINT.extensions
+                .firstOrNull { it.handlesDistribution(settings.distribution) } ?: return
+
+        val config = factory.assembleConfig(project)
+
+        val ruleProvider =
+            withServiceLoader {
+                try {
+                    val artifactProvider =
+                        ArtifactProviderFactory.getArtifactProvider(config, File(System.getProperty("user.home")))
+
+                    val pluginRepository: PluginRepository =
+                        PluginRepositoryFactory.getPluginRepository(
+                            config,
+                            javaClass.classLoader,
+                            artifactProvider,
+                        )
+
+                    RuleProvider.create(config, "", pluginRepository)
+                } catch (e: Exception) {
+                    project.notifyBalloon(
+                        MessageBundle.message("jqa.exception", e.message ?: "TwT"),
+                        NotificationType.ERROR,
+                    )
+                    null
+                }
+                // Default directories are handled through the config, since the plugin needs to make them absolute based on the maven project.
+            } ?: return
+
+        state.effectiveConfiguration = config
+        state.availableRuleSources = ruleProvider.ruleSources.mapNotNull { VfsUtil.findFileByURL(it.url) }
+        state.availableRules = ruleProvider.availableRules
+        state.effectiveRules = ruleProvider.effectiveRules
+
+        project.messageBus.syncPublisher(JqaSyncListener.TOPIC).synchronize(config)
+
+        project.notifyBalloon(MessageBundle.message("synchronized.jqa.config"))
     }
 
     /**
@@ -173,25 +215,14 @@ class JqaConfigurationService(
         jqaConfigFileProvider.addFileEventListener(listener)
     }
 
-    /**
-     * Returns the active configuration of the jQA Project.
-     */
-    fun getConfiguration(): CliConfiguration? {
-        val distribution = this.distribution ?: return null
-
-        val factory =
-            JqaConfigFactory.Util.EXTENSION_POINT.extensions
-                .firstOrNull { it.handlesDistribution(distribution) } ?: return null
-
-        return factory.assembleConfig(project) as CliConfiguration
-    }
+    fun getConfiguration(): FullArtifactConfiguration? = state.effectiveConfiguration
 
     /**
      * Get the rules currently available to jQA. This is very different to the rule index, which includes all rules
      * everywhere and disregards jQA config semantics.
      */
     fun getAvailableRules(): RuleSet =
-        object : RuleSet {
+        state.availableRules ?: object : RuleSet {
             override fun getConceptBucket(): ConceptBucket = ConceptBucket()
 
             override fun getProvidedConcepts(): MutableMap<String, MutableSet<String>> = mutableMapOf()
@@ -206,22 +237,17 @@ class JqaConfigurationService(
     /**
      * Get all files which are scanned by jQA for available rules.
      */
-    fun getAvailableRuleSources(): List<VirtualFile> = emptyList()
+    fun getAvailableRuleSources(): List<VirtualFile> = state.availableRuleSources
 
     /**
      * Get the currently effective rules.
      */
-    fun getEffectiveRules(): RuleSelection =
-        RuleSelection.select(
-            getAvailableRules(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-        )
+    fun getEffectiveRules(): CollectRulesVisitor? = state.effectiveRules
 
     /**
      * Whether the maven distribution is technically supported in the current IDE setup.
      */
-    fun isMavenDistributionSupported(): Boolean = true
+    fun isMavenDistributionSupported(): Boolean =
+        JqaConfigFactory.Util.EXTENSION_POINT.extensions
+            .any { it.handlesDistribution(JqaDistribution.MAVEN) }
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/MavenConfigFactory.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/config/MavenConfigFactory.kt
@@ -8,6 +8,7 @@ import com.buschmais.jqassistant.scm.maven.configuration.source.EmptyConfigSourc
 import com.buschmais.jqassistant.scm.maven.configuration.source.MavenProjectConfigSource
 import com.buschmais.jqassistant.scm.maven.configuration.source.MavenPropertiesConfigSource
 import com.buschmais.jqassistant.scm.maven.configuration.source.SettingsConfigSource
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
@@ -16,14 +17,23 @@ import io.smallrye.config.source.yaml.YamlConfigSource
 import org.apache.maven.model.Build
 import org.apache.maven.project.MavenProject
 import org.apache.maven.settings.Settings
-import org.eclipse.microprofile.config.spi.ConfigSource
 import org.jdom.Element
+import org.jetbrains.idea.maven.model.MavenPlugin
 import org.jetbrains.idea.maven.project.MavenProjectsManager
+import org.jqassistant.tooling.intellij.plugin.common.MyVfsUtil
+import org.jqassistant.tooling.intellij.plugin.common.notifyBalloon
 import org.jqassistant.tooling.intellij.plugin.common.withServiceLoader
+import org.jqassistant.tooling.intellij.plugin.editor.MessageBundle
+import org.jqassistant.tooling.intellij.plugin.settings.PluginSettings
 import java.io.File
 import java.util.Properties
 import kotlin.io.path.Path
 
+/**
+ * Representation of the settings configurable through pom.xml
+ *
+ * Parsing is done manually since using maven mapping logic doesn't seem to be possible.
+ */
 data class JqaMavenConfiguration(
     val yaml: String?,
     val configurationLocations: Set<String>,
@@ -50,12 +60,17 @@ data class JqaMavenConfiguration(
     }
 }
 
+/**
+ * Adapts an IntelliJ Maven Project model as normal MavenProject which is usable by jQA.
+ */
 class MavenProjectAdapter(
     val project: org.jetbrains.idea.maven.project.MavenProject,
+    private val description: String?,
+    private val scriptSource: String?,
 ) : MavenProject() {
     override fun getName(): String? = project.name
 
-    override fun getDescription(): String? = null
+    override fun getDescription(): String? = description
 
     override fun getGroupId(): String? = project.mavenId.groupId
 
@@ -69,6 +84,12 @@ class MavenProjectAdapter(
 
     override fun getBuild(): Build =
         object : Build() {
+            override fun getSourceDirectory(): String? = project.sources.singleOrNull()
+
+            override fun getTestSourceDirectory(): String? = project.testSources.singleOrNull()
+
+            override fun getScriptSourceDirectory(): String? = scriptSource
+
             override fun getDirectory(): String = project.directory
 
             override fun getOutputDirectory(): String = project.outputDirectory
@@ -79,6 +100,9 @@ class MavenProjectAdapter(
         }
 }
 
+/**
+ * Adapts an IntelliJ Maven Project as regular MavenSettings which are usable by jQA.
+ */
 class SettingsAdapter(
     val project: org.jetbrains.idea.maven.project.MavenProject,
 ) : Settings() {
@@ -93,38 +117,105 @@ class MavenConfigFactory : JqaConfigFactory {
 
     override fun handlesDistribution(distribution: JqaDistribution) = distribution == JqaDistribution.MAVEN
 
+    private fun MavenPlugin.isJqaPlugin() = groupId == JQA_MAVEN_PLUGIN_GROUP && artifactId == JQA_MAVEN_PLUGIN_ARTIFACT
+
+    private fun findMavenProject(
+        project: Project,
+        settings: PluginSettings.State,
+    ): Pair<org.jetbrains.idea.maven.project.MavenProject, JqaMavenConfiguration>? {
+        val mavenProjectManager = MavenProjectsManager.getInstance(project)
+        return if (settings.mavenProjectFile != null) {
+            // Check whether the selected maven project is valid.
+
+            val projectFile =
+                MyVfsUtil.findFileRelativeToProject(project, settings.mavenProjectFile)
+
+            if (projectFile == null) {
+                project.notifyBalloon(
+                    MessageBundle.message("multi.root.project.not.supported"),
+                    NotificationType.ERROR,
+                )
+                return null
+            }
+
+            val mavenProject = mavenProjectManager.findProject(projectFile)
+
+            if (mavenProject == null) {
+                project.notifyBalloon(
+                    MessageBundle.message(
+                        "invalid.maven.project",
+                        projectFile.presentableUrl,
+                    ),
+                    NotificationType.ERROR,
+                )
+                return null
+            }
+
+            val plugin = mavenProject.plugins.firstOrNull { it.isJqaPlugin() }
+
+            if (plugin == null) {
+                project.notifyBalloon(
+                    MessageBundle.message("maven.project.without.plugin", projectFile.presentableUrl),
+                    NotificationType.ERROR,
+                )
+                return null
+            }
+
+            Pair(
+                mavenProject,
+                JqaMavenConfiguration.fromJDomElement(plugin.configurationElement),
+            )
+        } else {
+            // Search for an arbitrary project that contains the jQA Plugin.
+
+            // Try root projects first.
+            val availableProjects =
+                mavenProjectManager.rootProjects +
+                    (mavenProjectManager.projects - mavenProjectManager.rootProjects.toSet())
+
+            for (mavenProject in availableProjects) {
+                val jqaMavenPlugin =
+                    mavenProject.plugins.firstOrNull {
+                        it.isJqaPlugin()
+                    } ?: continue
+                return Pair(
+                    mavenProject,
+                    JqaMavenConfiguration.fromJDomElement(jqaMavenPlugin.configurationElement),
+                )
+            }
+
+            project.notifyBalloon(MessageBundle.message("no.maven.project.with.plugin"), NotificationType.ERROR)
+            null
+        }
+    }
+
     override fun assembleConfig(project: Project): FullArtifactConfiguration? =
         // Use a class loader of the maven plugin, to pick up maven default plugins.
         withServiceLoader<AbstractRuleMojo, _> {
+            val settings = project.service<PluginSettings>().state
+
+            val service = project.service<JqaConfigurationService>()
+
             val configurationBuilder = ConfigurationBuilder("MojoConfigSource", 110)
 
-            val mavenProjectManager = MavenProjectsManager.getInstance(project)
-
             // Find any maven project that has the jqa maven plugin activated, so that we can access the config.
-            val (mavenProject, mavenConfig) =
-                run {
-                    for (mavenProject in mavenProjectManager.rootProjects) {
-                        val jqaMavenPlugin =
-                            mavenProject.plugins.firstOrNull { plugin ->
-                                plugin.groupId == JQA_MAVEN_PLUGIN_GROUP &&
-                                    plugin.artifactId == JQA_MAVEN_PLUGIN_ARTIFACT
-                            }
-                                ?: continue
-                        return@run mavenProject to
-                            JqaMavenConfiguration.fromJDomElement(jqaMavenPlugin.configurationElement)
-                    }
-                    return@withServiceLoader null
-                }
+            val (mavenProject, mavenConfig) = findMavenProject(project, settings) ?: return@withServiceLoader null
 
-            val projectConfigSource = MavenProjectConfigSource(MavenProjectAdapter(mavenProject))
+            val projectConfigSource =
+                MavenProjectConfigSource(
+                    MavenProjectAdapter(
+                        mavenProject,
+                        settings.mavenProjectDescription,
+                        settings.mavenScriptSourceDir,
+                    ),
+                )
+
             val settingsConfigSource = SettingsConfigSource(SettingsAdapter(mavenProject))
             val projectPropertiesConfigSource =
                 MavenPropertiesConfigSource(mavenProject.properties, "Maven Project Properties")
 
             val commandLineOptions =
-                project.service<JqaConfigurationService>().let {
-                    it.parseCommandLine(it.mavenParameters)
-                }
+                service.parseCommandLine(settings.mavenAdditionalProps)
 
             val userPropertiesConfigSource =
                 MavenPropertiesConfigSource(commandLineOptions.properties, "Maven Session User Properties ")
@@ -150,16 +241,13 @@ class MavenConfigFactory : JqaConfigFactory {
             val defaultDirectory = Path(mavenDir, "jqassistant")
 
             val defaultPathConfig =
-                object : ConfigSource {
-                    override fun getPropertyNames() = setOf("jqassistant.analyze.rule.directory")
-
-                    override fun getValue(propertyName: String?) =
-                        if (propertyName == "jqassistant.analyze.rule.directory") defaultDirectory.toString() else null
-
-                    override fun getName() = "InlineDummy"
-
-                    override fun getOrdinal() = 401
-                }
+                PropertiesConfigSource(
+                    mapOf(
+                        "jqassistant.analyze.rule.directory" to defaultDirectory.toString(),
+                    ),
+                    "InlineDummy",
+                    401,
+                )
 
             val configSources =
                 arrayOf(

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginService.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/data/plugin/JqaPluginService.kt
@@ -1,18 +1,17 @@
 package org.jqassistant.tooling.intellij.plugin.data.plugin
 
-import com.buschmais.jqassistant.commandline.configuration.CliConfiguration
 import com.buschmais.jqassistant.core.resolver.api.ArtifactProviderFactory
-import com.buschmais.jqassistant.core.shared.configuration.ConfigurationMappingLoader
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsListener
 import com.intellij.openapi.vfs.JarFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import io.smallrye.config.SysPropConfigSource
 import org.jqassistant.tooling.intellij.plugin.common.PluginUtil
+import org.jqassistant.tooling.intellij.plugin.data.config.JqaConfigurationService
 import java.io.File
 import kotlin.reflect.jvm.jvmName
 
@@ -87,7 +86,8 @@ class JqaPluginService(
     @Synchronized
     fun synchronizePlugins() {
         val config =
-            getJqaConfiguration() ?: return thisLogger().error("Problem constructing jQA-Config for plugin sync.")
+            project.service<JqaConfigurationService>().getConfiguration()
+                ?: return thisLogger().error("Problem constructing jQA-Config for plugin sync.")
 
         // TODO: Figure out builtin plugins.
         val plugins =
@@ -136,18 +136,5 @@ class JqaPluginService(
                 )
             }
         }
-    }
-
-    // TODO: Replace with configuration service that handles maven and everything config related.
-    private fun getJqaConfiguration(): CliConfiguration? {
-        val workingDirectory = project.basePath?.let { File(it) } ?: return null
-
-        return ConfigurationMappingLoader
-            .builder(CliConfiguration::class.java, listOf(".jqassistant.yaml"))
-            .withUserHome(userHome)
-            .withWorkingDirectory(workingDirectory)
-            .withEnvVariables()
-            .withClasspath()
-            .load(SysPropConfigSource())
     }
 }

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/config/SynchronizeConfig.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/editor/config/SynchronizeConfig.kt
@@ -1,0 +1,22 @@
+package org.jqassistant.tooling.intellij.plugin.editor.config
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import org.jqassistant.tooling.intellij.plugin.data.config.JqaConfigurationService
+
+/**
+ * Action to synchronize the [JqaConfigurationService].
+ *
+ * This is meant to be the user facing sync action of the plugin.
+ */
+class SynchronizeConfig : AnAction() {
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            project.service<JqaConfigurationService>().synchronize()
+        }
+    }
+}

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettings.kt
@@ -2,9 +2,9 @@
 package org.jqassistant.tooling.intellij.plugin.settings
 
 import com.intellij.openapi.components.BaseState
-import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
@@ -23,24 +23,56 @@ import org.jqassistant.tooling.intellij.plugin.data.config.JqaDistribution
     name = "jqassistant.JqaPluginSettings",
     storages = [Storage("jqaPluginSettings.xml", roamingType = RoamingType.PER_OS)],
 )
-internal class PluginSettings : PersistentStateComponent<PluginSettings.State> {
+internal class PluginSettings : SimplePersistentStateComponent<PluginSettings.State>(State()) {
     internal class State : BaseState() {
+        /**
+         * The distribution of this jQA project.
+         */
         var distribution by enum(JqaDistribution.CLI)
+
+        /**
+         * Execution root for the cli distribution.
+         *
+         * If `null` the project root is used.
+         */
         var cliExecRootDir by string()
+
+        /**
+         * Additional parameters used when the cli distribution is active.
+         */
         var cliParams by string()
+
+        /**
+         * Specific maven pom of the maven project to use for the maven distribution.
+         *
+         * If `null` searches for a maven project with the jQA plugin.
+         */
         var mavenProjectFile by string()
+
+        /**
+         * Additional parameters used when the maven distribution is active. They are parsed in the same format as
+         * cli parameters, but only properties are supported.
+         */
         var mavenAdditionalProps by string()
+
+        /**
+         * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
+         */
         var mavenProjectDescription by string()
+
+        /**
+         * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
+         */
         var mavenScriptSourceDir by string()
+
+        /**
+         * Used to compensate for a field of MavenProject that is not contained in the IntelliJ maven project model.
+         *
+         * Currently unused since the property which jQA searches doesn't exist in MavenProject.build.
+         * This is probably based on an older Maven version. We keep it configurable anyway so that we could use it
+         * if it became relevant.
+         */
         var mavenOutputEncoding by string()
-    }
-
-    private var myState = State()
-
-    override fun getState(): State = myState
-
-    override fun loadState(state: State) {
-        myState = state
     }
 
     companion object {

--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettingsComponent.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettingsComponent.kt
@@ -5,9 +5,9 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.setEmptyState
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.JBColor
@@ -33,7 +33,9 @@ class PluginSettingsComponent(
     // Misc
     private val mavenOrCliButtonGroup = ButtonGroup()
     val panel: JPanel
-    private val baseFile = LocalFileSystem.getInstance().findFileByPath(project.basePath ?: "")
+
+    // TODO: Find a proper solution for project root paths.
+    private val baseFile = project.guessProjectDir()
 
     // Labels
     private val labelBasePath = JLabel("Base path: ${baseFile?.presentableUrl}/").apply { isEnabled = false }
@@ -234,7 +236,6 @@ class PluginSettingsComponent(
             }
         }
 
-        // Make IntelliJ wait for tasks
         return state
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,10 @@
     </extensionPoints>
 
     <extensions defaultExtensionNs="com.intellij">
+        <notificationGroup id="jqassistant.NotificationBalloon"
+                           displayType="BALLOON"
+                           key="jqassistant.balloon.group"/>
+
         <toolWindow
             factoryClass="org.jqassistant.tooling.intellij.plugin.editor.config.toolwindow.EffectiveConfigToolWindowFactory"
             id="Effective Configuration"
@@ -132,6 +136,8 @@
         </action>
         <action id="SynchronizeJqaPlugins" text="Synchronize jQA Plugins"
                 class="org.jqassistant.tooling.intellij.plugin.editor.plugin.SynchronizePlugins"/>
+        <action id="SynchronizeJqaConfig" text="Synchronize jQA Config"
+                class="org.jqassistant.tooling.intellij.plugin.editor.config.SynchronizeConfig"/>
     </actions>
 
     <applicationListeners>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -112,6 +112,7 @@
     <extensions defaultExtensionNs="jqassistant">
         <jqaRuleIndexingStrategy
             implementation="org.jqassistant.tooling.intellij.plugin.data.rules.xml.JqaXmlRuleIndexingStrategy$Factory"/>
+        <jqaConfigFactory implementation="org.jqassistant.tooling.intellij.plugin.data.config.CliConfigFactory"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -3,6 +3,16 @@ org.jqassistant.tooling.intellij.inlay.description = Display inlay report result
 
 cannot.resolve = Cannot resolve symbol ''{0}''
 
+jqassistant.balloon.group = jQAssistant Support
+
+multi.root.project.not.supported = jQAssistant doesn't support projects with multiple roots. Configuration failed.
+invalid.maven.project = No maven project at {0}
+maven.project.without.plugin = The selected maven project at {0} does not have the jQAssistant plugin enabled. Is the right profile selected?
+no.maven.project.with.plugin = Could not find any maven project with the jQAssistant plugin. Is the right profile selected?
+jqa.exception = Could not configure jQAssistant due to the following error: {0}
+synchronized.jqa.config = Successfully synchronized jQAssistant configuration
+invalid.cmd.options = The provided options ''{0}'' are invalid
+
 inspections.group.name = jQAssistant Support
 inspection.rule.xml.validity.display.name = Xml rule source validity
 id.contains.wildcard.characters = Value contains reserved wildcard characters


### PR DESCRIPTION
Synchronization is currently manually via the "Sync jQA Config" action. After that the "Sync jQA Plugins" action can be used to synchronize plugins as well.

The cli distro doesn't seem to have any default config locations so configuring them in the settings is necessary. We should update the settings UI to make this clear or provide ".jqassistant.yaml" as default.

Known issues:
- The cli distro loads the Maven default plugins. Haven't figured out why, but it doesn't seem like a deal breaker to me.
