### PR TITLE
Misc: Use maven by default

### DIFF
--- a/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/jqassistant/tooling/intellij/plugin/settings/PluginSettings.kt
@@ -28,7 +28,7 @@ internal class PluginSettings : SimplePersistentStateComponent<PluginSettings.St
         /**
          * The distribution of this jQA project.
          */
-        var distribution by enum(JqaDistribution.CLI)
+        var distribution by enum(JqaDistribution.MAVEN)
 
         /**
          * Execution root for the cli distribution.


### PR DESCRIPTION
Maven is most likely the more popular and common setup for jQAssistant so it should be the default