### PR TITLE
Remove test workflow depency for release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
   releaseDraft:
     name: Release draft
     if: github.event_name != 'pull_request'
-    needs: [ build, test, verify ]
+    needs: [ build, verify ]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The test workflow is currently broken due to an error by IntelliJ and blocks the release Workflow, this is a temporary fix. Related to #126 